### PR TITLE
Prevent core option overriding when using 'config -set'

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -33,6 +33,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <memory>
+#include <set>
 #include <string>
 #include <thread>
 #ifdef _WIN32
@@ -57,7 +58,7 @@ bool startup_state_numlock;
 bool autofire;
 static bool dosbox_initialiazed = false;
 
-std::vector<std::string> locked_dosbox_variables;
+std::set<std::string> locked_dosbox_variables;
 
 Bit32u MIXER_RETRO_GetFrequency();
 void MIXER_CallBack(void* userdata, uint8_t* stream, int len);
@@ -274,10 +275,8 @@ auto update_dosbox_variable(
     }
 
     // Skip variables that are set via 'config -set'.
-    for (auto i : locked_dosbox_variables) {
-        if (i == var_string) {
-            return false;
-        }
+    if (locked_dosbox_variables.count(var_string) != 0) {
+        return false;
     }
 
     Section* section = control->GetSection(section_string);

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -57,6 +57,8 @@ bool startup_state_numlock;
 bool autofire;
 static bool dosbox_initialiazed = false;
 
+std::vector<std::string> locked_dosbox_variable;
+
 Bit32u MIXER_RETRO_GetFrequency();
 void MIXER_CallBack(void* userdata, uint8_t* stream, int len);
 
@@ -269,6 +271,13 @@ auto update_dosbox_variable(
     bool ret = false;
     if (dosbox_initialiazed && compare_dosbox_variable(section_string, var_string, val_string)) {
         return false;
+    }
+
+    /* Skip variables that are set via 'config -set' */
+    for (auto i : locked_dosbox_variable) {
+        if (i == var_string) {
+            return false;
+        }
     }
 
     Section* section = control->GetSection(section_string);

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -274,8 +274,9 @@ auto update_dosbox_variable(
         return false;
     }
 
-    // Skip variables that are set via 'config -set'.
-    if (locked_dosbox_variables.count(var_string) != 0) {
+    if (locked_dosbox_variables.count(var_string) != 0
+        && retro::core_options["option_handling"].toString() == "disable changed")
+    {
         return false;
     }
 
@@ -683,7 +684,7 @@ static void check_variables()
     use_spinlock = core_options["thread_sync"].toString() == "spin";
     useSpinlockThreadSync(use_spinlock);
 
-    if (!core_options["use_options"].toBool()) {
+    if (core_options["option_handling"].toString() == "all off") {
         return;
     }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -57,7 +57,7 @@ bool startup_state_numlock;
 bool autofire;
 static bool dosbox_initialiazed = false;
 
-std::vector<std::string> locked_dosbox_variable;
+std::vector<std::string> locked_dosbox_variables;
 
 Bit32u MIXER_RETRO_GetFrequency();
 void MIXER_CallBack(void* userdata, uint8_t* stream, int len);
@@ -273,8 +273,8 @@ auto update_dosbox_variable(
         return false;
     }
 
-    /* Skip variables that are set via 'config -set' */
-    for (auto i : locked_dosbox_variable) {
+    // Skip variables that are set via 'config -set'.
+    for (auto i : locked_dosbox_variables) {
         if (i == var_string) {
             return false;
         }

--- a/libretro/libretro_core_options.cpp
+++ b/libretro/libretro_core_options.cpp
@@ -43,17 +43,20 @@ CoreOptions core_options {
     "dosbox_core_",
 
     CoreOptionDefinition {
-        "use_options",
-        "Enable core options (restart)",
-        "Disabling core options can be useful if you prefer to use dosbox .conf files to set "
-            "configuration settings. Note that you can still use core options together with "
-            ".conf files, for example if your .conf files only contain an [autoexec] section, "
-            "or dosbox settings not yet available as core options.",
+        "option_handling",
+        "Core option handling",
+        "Disabling all core options can be useful if you prefer to use dosbox .conf files to set "
+            "configuration settings. Note that you don't need to disable all options if your .conf "
+            "file only contains an [autoexec] section. Disabling only core options that have been "
+            "changed within dosbox (using the 'config -set' DOS command, for example) prevents "
+            "those changes from getting reverted to the values set in the core options. This is "
+            "the default and recommended setting.",
         {
-            true,
-            false,
+            {"disable changed", "disable options changed within dosbox"},
+            {"all on", "enable all options (restart)"},
+            {"all off", "disable all options (restart)"},
         },
-        true
+        "disable changed"
     },
     CoreOptionDefinition {
         "adv_options",

--- a/libretro/libretro_dosbox.h
+++ b/libretro/libretro_dosbox.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <string>
+#include <vector>
 
 #define RETRO_DEVICES 5
 
@@ -46,3 +47,5 @@ void core_autoexec();
 auto update_dosbox_variable(
     bool autoexec, const std::string& section_string, const std::string& var_string,
     const std::string& val_string) -> bool;
+
+extern std::vector<std::string> locked_dosbox_variable;

--- a/libretro/libretro_dosbox.h
+++ b/libretro/libretro_dosbox.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <string>
-#include <vector>
+#include <set>
 
 #define RETRO_DEVICES 5
 
@@ -37,7 +37,7 @@ extern float mouse_speed_factor_y;
 extern std::array<bool, 16> connected;
 extern bool gamepad[16];
 extern bool emulated_mouse;
-extern std::vector<std::string> locked_dosbox_variables;
+extern std::set<std::string> locked_dosbox_variables;
 
 namespace retro {
 class CoreOptions;

--- a/libretro/libretro_dosbox.h
+++ b/libretro/libretro_dosbox.h
@@ -37,6 +37,7 @@ extern float mouse_speed_factor_y;
 extern std::array<bool, 16> connected;
 extern bool gamepad[16];
 extern bool emulated_mouse;
+extern std::vector<std::string> locked_dosbox_variables;
 
 namespace retro {
 class CoreOptions;
@@ -47,5 +48,3 @@ void core_autoexec();
 auto update_dosbox_variable(
     bool autoexec, const std::string& section_string, const std::string& var_string,
     const std::string& val_string) -> bool;
-
-extern std::vector<std::string> locked_dosbox_variable;

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -40,6 +40,10 @@ Bitu call_program;
 #include "nonlibc.h"
 #endif
 
+#ifdef __LIBRETRO__
+#include "libretro_dosbox.h"
+#endif
+
 /* This registers a file on the virtual drive and creates the correct structure for it*/
 
 static Bit8u exe_block[]={
@@ -751,6 +755,11 @@ void CONFIG::Run(void) {
 			}
 			std::string inputline = pvars[1] + "=" + value;
 			
+#ifdef __LIBRETRO__
+			/* Store variables for core option skipping */
+			locked_dosbox_variable.push_back(pvars[1]);
+#endif
+
 			tsec->ExecuteDestroy(false);
 			bool change_success = tsec->HandleInputline(inputline.c_str());
 			if (!change_success) WriteOut(MSG_Get("PROGRAM_CONFIG_VALUE_ERROR"),

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -756,8 +756,8 @@ void CONFIG::Run(void) {
 			std::string inputline = pvars[1] + "=" + value;
 			
 #ifdef __LIBRETRO__
-			/* Store variables for core option skipping */
-			locked_dosbox_variable.push_back(pvars[1]);
+			// Store variables for core option skipping.
+			locked_dosbox_variables.emplace_back(pvars[1]);
 #endif
 
 			tsec->ExecuteDestroy(false);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -757,7 +757,7 @@ void CONFIG::Run(void) {
 			
 #ifdef __LIBRETRO__
 			// Store variables for core option skipping.
-			locked_dosbox_variables.emplace_back(pvars[1]);
+			locked_dosbox_variables.insert(pvars[1]);
 #endif
 
 			tsec->ExecuteDestroy(false);


### PR DESCRIPTION
This allows locking dosbox variables with `config -set` command so that core options will not override them.

Maybe it could use some logging..?
