### PR TITLE
Add directories to the list of supported content path types

### DIFF
--- a/libretro/dosbox_core_libretro.info
+++ b/libretro/dosbox_core_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "DOS (DOSBox-core)"
 authors = "DOSBox Team|radius|Nikos Chantziaras"
-supported_extensions = "exe|com|bat|conf|cue|iso"
+supported_extensions = "exe|com|bat|conf|cue|iso|img|/"
 corename = "DOSBox-core"
 categories = "Emulator"
 license = "GPLv2"

--- a/libretro/src/libretro.cpp
+++ b/libretro/src/libretro.cpp
@@ -1004,7 +1004,7 @@ void retro_get_system_info(retro_system_info* const info)
 {
     info->library_name = retro_library_name.c_str();
     info->library_version = CORE_VERSION;
-    info->valid_extensions = "exe|com|bat|conf|cue|iso|img";
+    info->valid_extensions = "exe|com|bat|conf|cue|iso|img|/";
     info->need_fullpath = true;
     info->block_extract = false;
 }


### PR DESCRIPTION
Recently libretro/RetroArch#17142 got merged into RetroArch which adds a new selection at the top of the content browser `<Use This Directory>` to load the path to the directory itself (not a file) as the content. This was always supported in RetroArch but it was only possible either by manually writing a playlist file or by launching RetroArch with `-L "core.so" "/directory/path"`, but not via the menu. Partially this was because a core couldn't tell the frontend that it supports loading directories. Now with the mentioned PR merged, a core can have "/" in its list of supported extensions to indicate support for loading directories.

The copy of the .info file actually distributed by RetroArch's online updater has also had a separate PR just added at libretro/libretro-super#1858