### PR TITLE
Fix cross-compilation

### DIFF
--- a/libretro/Makefile.libretro
+++ b/libretro/Makefile.libretro
@@ -63,8 +63,8 @@ AS:=$(cross_prefix)$(AS)
 CC:=$(cross_prefix)$(CC)
 CXX:=$(cross_prefix)$(CXX)
 LD:=$(cross_prefix)$(LD)
-CMAKE=$(cross_prefix)cmake
-PKGCONFIG=$(cross_prefix)pkg-config
+CMAKE=cmake
+PKGCONFIG=pkg-config
 
 platform ?= unix
 ifneq ($(findstring MINGW,$(UNAME)),)


### PR DESCRIPTION
The `cmake` and `pkg-config` versions that are supposed to be used on a cross-compilation environment are the ones on the machine where the build is being done.

For example, by doing this while trying to cross-compile for aarch64:
```
CMAKE=$(cross_prefix)cmake
PKGCONFIG=$(cross_prefix)pkg-config
```
...we would be trying to use something like `aarch64-linux-gnu-cmake` and `aarch64-linux-gnu-pkg-config` which don't exist and don't have any sense: plain `cmake` and `pkg-config` are supposed to be used instead, even if the libs live under a foreign architecture rootfs.
