### PR TITLE
add webOS to Makefile / CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,11 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/android-jni.yml'
 
+  #################################### MISC ##################################
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -288,3 +293,10 @@ android-x86:
     - $NDK_ROOT/ndk-build --no-print-directory -j$NUMPROC -C $JNI_PATH/jni $PLATFORM_ARGS
     - mv $JNI_PATH/libs/$ANDROID_ABI/libretro.so $LIBNAME
     - if [ $STRIP_CORE_LIB -eq 1 ]; then $NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip $LIBNAME; fi
+
+#################################### MISC ##################################
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
+    - .core-defs

--- a/libretro/Makefile.libretro
+++ b/libretro/Makefile.libretro
@@ -173,6 +173,24 @@ else
 	LDFLAGS += -Wl,-Bdynamic
 	fpic = -fPIC
 endif
+
+CORE_DIR := ..
+DEPS_BIN_DIR = $(CURDIR)/deps_bin
+
+# webOS
+ifneq (,$(or $(findstring webos,$(CROSS_COMPILE)),$(findstring starfish,$(CROSS_COMPILE))))
+	TARGET_TRIPLET = $(patsubst %-,%,$(CROSS_COMPILE))
+	WITH_FLUIDSYNTH = 1
+	WITH_FAKE_SDL = 1
+	ifneq (,$(findstring aarch64,$(CROSS_COMPILE)))
+		WITH_DYNAREC = arm64
+	else
+		WITH_DYNAREC = arm
+	endif
+	INCFLAGS += -I$(DEPS_BIN_DIR)/include -I$(DEPS_BIN_DIR)/munt_build/include -I$(DEPS_BIN_DIR)/opus/include
+	LDFLAGS += -L$(DEPS_BIN_DIR)/lib
+endif
+
 ifeq ($(DEBUG), 1)
 	COMMONFLAGS += -O0 -g
 	CMAKE_BUILD_TYPE = Debug
@@ -199,12 +217,10 @@ ifeq ($(WITH_VOODOO), 1)
 	COMMONFLAGS += -DWITH_VOODOO
 endif
 
-CORE_DIR := ..
-INCFLAGS :=
+INCFLAGS ?=
 SOURCES_C :=
 SOURCES_CXX :=
 
-DEPS_BIN_DIR = $(CURDIR)/deps_bin
 ifeq ($(BUNDLED_SDL), 1)
 	include deps/sdl.makefile
 	include deps/sdl_net.makefile


### PR DESCRIPTION
This allows compilation for webOS

Note i've had to add INCFLAGS/LDFLAGS to build, as GCC 14 doesn't seem to find them otherwise.

Also these are the libs are built:

```
find ./ -name *.a
./deps/sdl/os2/lib/FSLib.a
./deps_bin/vorbis_build/lib/libvorbisenc.a
./deps_bin/vorbis_build/lib/libvorbis.a
./deps_bin/vorbis_build/lib/libvorbisfile.a
./deps_bin/ogg_build/libogg.a
./deps_bin/libsndfile_build/libsndfile.a
./deps_bin/opus_build/libopus.a
./deps_bin/fluidsynth_build/src/libfluidsynth.a
./deps_bin/flac_build/src/test_libs_common/.libs/libtest_libs_common.a
./deps_bin/flac_build/src/libFLAC/.libs/libFLAC.a
./deps_bin/flac_build/src/libFLAC/.libs/libFLAC-static.a
./deps_bin/flac_build/src/share/grabbag/.libs/libgrabbag.a
./deps_bin/flac_build/src/share/replaygain_synthesis/.libs/libreplaygain_synthesis.a
./deps_bin/flac_build/src/share/getopt/.libs/libgetopt.a
./deps_bin/flac_build/src/share/replaygain_analysis/.libs/libreplaygain_analysis.a
./deps_bin/flac_build/src/share/utf8/.libs/libutf8.a
./deps_bin/munt_build/libmt32emu.a
./deps_bin/lib/libfluidsynth.a
./deps_bin/lib/libogg.a
./deps_bin/lib/libvorbisenc.a
./deps_bin/lib/libopus.a
./deps_bin/lib/libvorbis.a
./deps_bin/lib/libsndfile.a
./deps_bin/lib/libFLAC.a
./deps_bin/lib/libvorbisfile.a
./deps_bin/lib/libmt32emu.a
```

Which is missing libmpg123.a and libopusfile.a, referenced in Makefile.libretro. Are they needed?